### PR TITLE
update distro dependencies and README

### DIFF
--- a/deepsea/defaults.yaml
+++ b/deepsea/defaults.yaml
@@ -27,11 +27,16 @@ deepsea:
     dev_env: True
 
   packages:
-    # Set True if https://github.com/saltstack-formulas/packages-formula is used/preferred
-    formula: False
+    # Should this formula manage package dependencies? True means yes; False NO.
+    # Ideally `DeepSea` (or `packages-formula`) should handle package dependencies.
+    managed: False
     required:
       - python-setuptools
+      - python3-boto
+      - python3-rados
+      - lsscsi
+      - jq
+      - pciutils
       - salt-api
       - git
       - make
-

--- a/deepsea/install.sls
+++ b/deepsea/install.sls
@@ -6,18 +6,11 @@
 include:
   - deepsea.config
   - deepsea.service
-
-deepsea-requirements:
-   {% if not deepsea.packages.formula %}
-  pkg.installed:
-    - pkgs:
-      - make
-      {% for pkg in deepsea.packages.required %}
-      - {{ pkg }}
-      {% endfor %}
-    - require_in:
-      - file: deepsea-requirements
+   {% if deepsea.packages.managed %}
+  - deepsea.packages
    {% endif %}
+
+deepsea-directories:
   file.directory:
     - names:
        - /etc/salt/master.d
@@ -42,7 +35,7 @@ deepsea-software:
     - gpgcheck: 1
     - gpgautoimport: True
     - require:
-      - file: deepsea-requirements
+      - file: deepsea-directories
   pkg.installed:
     - pkgs: {{ deepsea.packages.required }}
     - require:
@@ -72,7 +65,7 @@ deepsea-software:
     - cwd: {{ deepsea.tmpdir }}/DeepSea
    {% endif %}
     - require:
-      - file: deepsea-requirements
+      - file: deepsea-directories
       - pkgrepo: deepsea-software
     - require_in:
       - file: deepsea-config-global

--- a/deepsea/osfamilymap.yaml
+++ b/deepsea/osfamilymap.yaml
@@ -16,16 +16,17 @@ Suse:
     dead:
       - apparmor
       - SuSEfirewall2
+  packages:
+    required:
+      - gptfdisk
+      - iperf
+      - lsof
 
 Debian:
   packages:
-    # Set True if https://github.com/saltstack-formulas/packages-formula is used/preferred
-    formula: False
     required:
-      - python-setuptools
-      - python-click
-      - python-tox
-      - salt-api
+      - gdisk
+      - iperf
 
 RedHat:
   services:
@@ -33,10 +34,12 @@ RedHat:
       - ntpd
       - salt-minion
   packages:
-    # Set True if https://github.com/saltstack-formulas/packages-formula is used/preferred
-    formula: False
     required:
-      - python-setuptools
       - python-click
       - python-tox
-      - salt-api
+      - python-netaddr
+      - iperf3
+      - gdisk
+      - lshw
+      - hwinfo
+

--- a/deepsea/packages.sls
+++ b/deepsea/packages.sls
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+
+{% from "deepsea/map.jinja" import deepsea with context -%}
+
+   {% if deepsea.packages.managed %}
+
+deepsea-packages-common-dependencies:
+  pkg.installed:
+    - pkgs:
+      - make
+      {% for pkg in deepsea.packages.required %}
+      - {{ pkg }}
+      {% endfor %}
+
+   {% endif %}


### PR DESCRIPTION
Improvements to formula - verified on Ubuntu 16.04 with latest Deepsea
- let DeepSea handle package dependencies (split into optional `packages.sls` state).
- update README examples
- update package dependencies in defaults/osfamilymap (not required on Ubuntu 16.04).
