### PR TITLE
fix(salt): salt-api must run under python3

### DIFF
--- a/deepsea/files/default/Makefile
+++ b/deepsea/files/default/Makefile
@@ -978,6 +978,12 @@ install: pyc install-deps copy-files
 	# Use '|| true' to suppress some error output in corner cases
 	systemctl restart salt-master
 	systemctl restart salt-api
+	if (( $? > 0 ))
+	then
+	    cp /usr/bin/salt-api /usr/bin/salt-api.orig 2>/dev/null
+	    sed 's#\/usr\/bin\/python2#/usr/bin/python3#' /usr/bin/salt-api.orig > /usr/bin/salt-api 2>/dev/null
+	    systemctl restart salt-api
+	fi
 	# deepsea-cli
 	$(PYTHON) setup.py install --root=$(DESTDIR)/
 


### PR DESCRIPTION
This is workaround for https://saltstackcommunity.slack.com/archives/C7K04SEJC/p1562184878424500

> On Ubuntu the `salt-api 2019.2.0+ds-1` package has hard dependency on python2 so will not work on python3 only OS.  What should I do?


> root@ubuntu1804:~# dpkg-query --list | grep salt-api
> ii salt-api               2019.2.0+ds-1 all     Generic, modular network access system


> root@ubuntu1804:~# apt-get install --reinstall salt-api
> Reading package lists... Done
> Building dependency tree    
> Reading state information... Done
> The following packages were automatically installed and are no longer required:
>  python3-cherrypy3 python3-repoze.lru python3-routes python3-simplejson python3-webob
> Use 'apt autoremove' to remove them.
> 0 upgraded, 0 newly installed, 1 reinstalled, 0 to remove and 148 not upgraded.
> Need to get 0 B/13.0 kB of archives.
> After this operation, 0 B of additional disk space will be used.
> (Reading database ... 124806 files and directories currently installed.)
> Preparing to unpack .../salt-api_2019.2.0+ds-1_all.deb ...
> Unpacking salt-api (2019.2.0+ds-1) over (2019.2.0+ds-1) ...
> Processing triggers for ureadahead (0.100.0-20) ...
> Processing triggers for systemd (237-3ubuntu10.12) ...
> Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
> Setting up salt-api (2019.2.0+ds-1) ...
> invoke-rc.d: policy-rc.d denied execution of restart.


> root@ubuntu1804:~# head /usr/bin/salt-api
> #! /usr/bin/python2
>     # Import salt libs
> from salt.scripts import salt_api
> if __name__ == '__main__':
>   salt_api()
> Collapse


> As workaround I use sed to replace with `python3` and restart the `salt-api` service.