### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/deepsea/defaults.yaml
+++ b/deepsea/defaults.yaml
@@ -13,8 +13,8 @@ deepsea:
       - salt-api
       - tar
       - gzip
-    use_upstream_repo: False
-    use_upstream_source: True
+    use_upstream_repo: false
+    use_upstream_source: true
     repo:
       comments:
         - installed by salt
@@ -22,11 +22,12 @@ deepsea:
       name: /tmp/deepsea
       uri: 'https://github.com/SUSE/DeepSea/archive/'
       source: None
-      source_hash: 88faf687a56060bf08da6ec3cf26917351e843efc4de0489139391d7e6985733  #linux amd64 tarball
-      trim_output: True   {# works in 2018.3.2. onwards #}
+      # linux amd64 tarball
+      source_hash: 88faf687a56060bf08da6ec3cf26917351e843efc4de0489139391d7e6985733
+      trim_output: true  # works in 2018.3.2. onwards
       archive_suffix: tar.gz
       archive_format: tar
-      enforce_toplevel: False
+      enforce_toplevel: false
       options: '--strip-components=1'
 
   kernel: ''
@@ -35,7 +36,7 @@ deepsea:
   environ_file: /etc/default/deepsea.sh
   environ:
     export DEV_ENV=False
-    
+
   service:
     user: salt
     group: salt
@@ -43,5 +44,5 @@ deepsea:
     dead: []
 
   linux:
-    #'Alternatives system' priority: zero disables (default)
+    # 'Alternatives system' priority: zero disables (default)
     altpriority: 0

--- a/deepsea/osfamilymap.yaml
+++ b/deepsea/osfamilymap.yaml
@@ -23,7 +23,7 @@ Debian:
 RedHat:
   service:
     name: deepsea
-    enabled: False
+    enabled: false
   pkg:
     deps:
       # python-boto3
@@ -34,7 +34,7 @@ RedHat:
 
 Suse:
   pkg:
-    use_upstream_repo: True
+    use_upstream_repo: true
     deps:
       - python3-tox
       # python3-boto3
@@ -45,10 +45,12 @@ Suse:
     repo:
       name: 'Filesystem tools and FUSE-related packages (openSUSE_Leap_$releasever)'
       humanname: 'Filesystem tools and FUSE-related packages'
+      # yamllint disable rule:line-length
       baseurl: 'http://download.opensuse.org/repositories/filesystems/openSUSE_Leap_$releasever/$basearch'
       gpgkey: 'http://download.opensuse.org/repositories/filesystems/openSUSE_Leap_42.3/repodata/repomd.xml.key'
+      # yamllint enable rule:line-length
       gpgcheck: 1
-      gpgautoimport: True
+      gpgautoimport: true
   service:
     dead:
       - apparmor

--- a/pillar.example
+++ b/pillar.example
@@ -4,7 +4,7 @@
 deepsea:
   version: '0.9.22'
   pkg:
-    use_upstream_source: True
+    use_upstream_source: true
     archive:
       uri: https://dl.deepsea.com/oss/release
 
@@ -38,12 +38,10 @@ deepsea:
     # dirs:
     #   files: files_alt
     #   default: default_alt
-    # source_files:
-    #   deepsea-config-file-file-managed:
-    #     - 'example_alt.tmpl'
-    #     - 'example_alt.tmpl.jinja'
+    source_files:
+      deepsea-config-file-file-managed:
+        - 'alt_environ.sh.jinja'
 
   linux:
-    #'Alternatives system' priority: zero disables (default)
+    # 'Alternatives system' priority: zero disables (default)
     altpriority: 1000
-

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: deepsea formula
 maintainer: SaltStack Formulas


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
deepsea-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./deepsea/defaults.yaml
  16:24     warning  truthy value should be one of [false, true]  (truthy)
  17:26     warning  truthy value should be one of [false, true]  (truthy)
  25:87     warning  missing starting space in comment  (comments)
  25:89     error    line too long (105 > 88 characters)  (line-length)
  26:57     warning  too few spaces before comment  (comments)
  26:58     warning  missing starting space in comment  (comments)
  29:25     warning  truthy value should be one of [false, true]  (truthy)
  38:1      error    trailing spaces  (trailing-spaces)
  46:6      warning  missing starting space in comment  (comments)

./deepsea/osfamilymap.yaml
  26:14     warning  truthy value should be one of [false, true]  (truthy)
  37:24     warning  truthy value should be one of [false, true]  (truthy)
  48:89     error    line too long (106 > 88 characters)  (line-length)
  49:89     error    line too long (112 > 88 characters)  (line-length)
  51:22     warning  truthy value should be one of [false, true]  (truthy)

pillar.example
  7:26      warning  truthy value should be one of [false, true]  (truthy)
  35:5      warning  comment not indented like content  (comments-indentation)
  47:6      warning  missing starting space in comment  (comments)
  49:1      error    too many blank lines (1 > 0)  (empty-lines)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.